### PR TITLE
chore: remove redundant nanoid override

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   },
   "overrides": {
     "@babel/runtime": "7.29.2",
-    "nanoid": "3.3.11",
     "postcss": "8.5.10",
     "socket.io-parser": "4.2.6"
   }


### PR DESCRIPTION
## Summary
- remove the root `nanoid` override from `package.json`
- keep `nanoid` only as a transitive dependency of `postcss`/Next.js
- close the obsolete nanoid upgrade PRs because the app does not use nanoid directly

## Why
The app has no direct `nanoid` usage. The only remaining `nanoid` install comes from `postcss` under Next.js, so the repo-level override was just extra churn.

## Test Plan
- `npm install`
- `npm ls nanoid --all`
- `npm run build`
- `npm run type-check`
- `npm audit --omit=dev --json`